### PR TITLE
Fix: Load ChildrenCardsView when visiting root path instead of LoginView

### DIFF
--- a/src/routes/HomeRoutes.js
+++ b/src/routes/HomeRoutes.js
@@ -14,7 +14,7 @@ const HomeRoutes = {
     {
       exact: true,
       path: '/',
-      component: lazy(() => import('src/views/auth/LoginView'))
+      component: lazy(() => import('src/views/user/ChildrenCardsView'))
     },
     {
       exact: true,


### PR DESCRIPTION
This PR fixes that uncomfortable bug I created months ago,  that caused the `LoginView` component to be loaded even if the user was already logged in.

`ChildrenCardsView` will be loaded when visting root path `<HOST>/`